### PR TITLE
Migrate settings from ~/.claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ claudewho add personal
 claudewho add client-project
 ```
 
+### Migrate settings from ~/.claude
+
+Copy your existing Claude Code configuration to a new account:
+
+```bash
+# During account creation
+claudewho add work --migrate
+
+# Or after creating an account
+claudewho migrate work
+```
+
+This copies your settings, skills, plugins, and project history. An interactive selector lets you choose which project groups to include. Running it again on the same account is safe — existing items are skipped.
+
 ### List accounts
 
 ```bash
@@ -86,6 +100,7 @@ This will prompt for confirmation before deleting the account directory.
 |---------|-------------|
 | `list` | List all configured accounts |
 | `add <name>` | Create a new account configuration |
+| `migrate <name>` | Migrate settings and projects from ~/.claude |
 | `remove <name>` | Remove an account (with confirmation) |
 | `use <name>` | Switch to the specified account |
 | `ide-setup` | Configure IDE integration (VSCode) |

--- a/bin/claudewho
+++ b/bin/claudewho
@@ -384,6 +384,160 @@ find_common_prefix() {
     echo "$prefix"
 }
 
+# Interactive project group selector and copier
+# Args: $1 = source_dir (e.g. ~/.claude), $2 = target_dir (e.g. ~/.claudewho-work)
+select_and_copy_projects() {
+    local source_dir="$1"
+    local target_dir="$2"
+    local projects_dir="$source_dir/projects"
+
+    if [[ ! -d "$projects_dir" ]]; then
+        return 0
+    fi
+
+    # Collect all project directory names
+    local all_dirs=()
+    for d in "$projects_dir"/*/; do
+        [[ -d "$d" ]] || continue
+        all_dirs+=("$(basename "$d")")
+    done
+
+    if [[ ${#all_dirs[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    # Build group keys and counts
+    declare -A group_counts
+    for dirname in "${all_dirs[@]}"; do
+        local key
+        key=$(project_group_key "$dirname")
+        group_counts["$key"]=$(( ${group_counts["$key"]:-0} + 1 ))
+    done
+
+    # Sort group keys
+    local sorted_keys=()
+    while IFS= read -r key; do
+        sorted_keys+=("$key")
+    done < <(printf '%s\n' "${!group_counts[@]}" | sort)
+
+    # Find common prefix for shorter display
+    local common_prefix
+    common_prefix=$(printf '%s\n' "${sorted_keys[@]}" | find_common_prefix)
+
+    # Build display labels (strip common prefix)
+    local display_labels=()
+    for key in "${sorted_keys[@]}"; do
+        display_labels+=("${key#"$common_prefix"}")
+    done
+
+    # Selection state (0 = unselected, 1 = selected)
+    local selected=()
+    for (( i=0; i<${#sorted_keys[@]}; i++ )); do
+        selected+=(0)
+    done
+
+    local total=${#all_dirs[@]}
+
+    # Interactive loop
+    while true; do
+        echo ""
+        echo -e "${BOLD}Select project groups to migrate${NC} ($total projects in $projects_dir/):"
+        echo ""
+        for (( i=0; i<${#sorted_keys[@]}; i++ )); do
+            local check=" "
+            [[ "${selected[$i]}" -eq 1 ]] && check="x"
+            local count=${group_counts[${sorted_keys[$i]}]}
+            local label="${display_labels[$i]}"
+            local unit="projects"
+            [[ "$count" -eq 1 ]] && unit="project"
+            printf "  %2d. [%s] %s (%d %s)\n" "$((i+1))" "$check" "$label" "$count" "$unit"
+        done
+        echo ""
+        echo -e "Toggle: ${BOLD}1-${#sorted_keys[@]}${NC}, ${BOLD}a${NC}=all, ${BOLD}n${NC}=none, ${BOLD}enter${NC}=done"
+
+        read -rp "> " input
+
+        # Empty input = done
+        if [[ -z "$input" ]]; then
+            break
+        fi
+
+        # Handle special commands
+        case "$input" in
+            a|A)
+                for (( i=0; i<${#sorted_keys[@]}; i++ )); do
+                    selected[$i]=1
+                done
+                continue
+                ;;
+            n|N)
+                for (( i=0; i<${#sorted_keys[@]}; i++ )); do
+                    selected[$i]=0
+                done
+                continue
+                ;;
+        esac
+
+        # Handle comma-separated numbers and individual numbers
+        IFS=',' read -ra tokens <<< "$input"
+        for token in "${tokens[@]}"; do
+            # Trim whitespace
+            token=$(echo "$token" | tr -d ' ')
+            if [[ "$token" =~ ^[0-9]+$ ]] && [[ "$token" -ge 1 ]] && [[ "$token" -le ${#sorted_keys[@]} ]]; then
+                local idx=$((token - 1))
+                if [[ "${selected[$idx]}" -eq 0 ]]; then
+                    selected[$idx]=1
+                else
+                    selected[$idx]=0
+                fi
+            fi
+        done
+    done
+
+    # Collect selected group keys
+    local selected_keys=()
+    for (( i=0; i<${#sorted_keys[@]}; i++ )); do
+        if [[ "${selected[$i]}" -eq 1 ]]; then
+            selected_keys+=("${sorted_keys[$i]}")
+        fi
+    done
+
+    if [[ ${#selected_keys[@]} -eq 0 ]]; then
+        echo -e "  ${DIM}No project groups selected${NC}"
+        return 0
+    fi
+
+    # Copy matching projects
+    mkdir -p "$target_dir/projects"
+    local copied=0
+    local skipped=0
+    for dirname in "${all_dirs[@]}"; do
+        local key
+        key=$(project_group_key "$dirname")
+        local match="false"
+        for sel_key in "${selected_keys[@]}"; do
+            if [[ "$key" == "$sel_key" ]]; then
+                match="true"
+                break
+            fi
+        done
+        if [[ "$match" == "true" ]]; then
+            if [[ -d "$target_dir/projects/$dirname" ]]; then
+                ((skipped++))
+            else
+                cp -R "$projects_dir/$dirname" "$target_dir/projects/$dirname"
+                ((copied++))
+            fi
+        fi
+    done
+
+    if [[ $copied -gt 0 ]]; then
+        echo -e "  ${GREEN}Copied${NC} projects/ ($copied copied"$([[ $skipped -gt 0 ]] && echo ", $skipped skipped")")"
+    elif [[ $skipped -gt 0 ]]; then
+        echo -e "  ${YELLOW}Skipped${NC} projects/ ($skipped already exist)"
+    fi
+}
+
 # Migrate configuration from default .claude directory
 migrate_default_config() {
     local target_dir="$1"

--- a/bin/claudewho
+++ b/bin/claudewho
@@ -672,10 +672,13 @@ add_account() {
     echo "Launch Claude with this account:"
     echo "    claudewho-${name}"
 
-    # Run migration if requested
+    # Run migration if requested, otherwise show tip
     if [[ "$migrate" == "true" ]]; then
         echo ""
         migrate_default_config "$dir"
+    else
+        echo ""
+        echo -e "${DIM}Tip: Run 'claudewho migrate ${name}' to copy settings and projects from ~/.claude${NC}"
     fi
 }
 

--- a/bin/claudewho
+++ b/bin/claudewho
@@ -407,19 +407,17 @@ select_and_copy_projects() {
         return 0
     fi
 
-    # Build group keys and counts
-    declare -A group_counts
-    for dirname in "${all_dirs[@]}"; do
-        local key
-        key=$(project_group_key "$dirname")
-        group_counts["$key"]=$(( ${group_counts["$key"]:-0} + 1 ))
-    done
-
-    # Sort group keys
+    # Build sorted group keys with counts (parallel indexed arrays, Bash 3 compatible)
     local sorted_keys=()
-    while IFS= read -r key; do
+    local group_counts=()
+    while read -r count key; do
         sorted_keys+=("$key")
-    done < <(printf '%s\n' "${!group_counts[@]}" | sort)
+        group_counts+=("$count")
+    done < <(
+        for dirname in "${all_dirs[@]}"; do
+            project_group_key "$dirname"
+        done | sort | uniq -c | sed 's/^ *//'
+    )
 
     # Find common prefix for shorter display
     local common_prefix
@@ -447,7 +445,7 @@ select_and_copy_projects() {
         for (( i=0; i<${#sorted_keys[@]}; i++ )); do
             local check=" "
             [[ "${selected[$i]}" -eq 1 ]] && check="x"
-            local count=${group_counts[${sorted_keys[$i]}]}
+            local count=${group_counts[$i]}
             local label="${display_labels[$i]}"
             local unit="projects"
             [[ "$count" -eq 1 ]] && unit="project"

--- a/bin/claudewho
+++ b/bin/claudewho
@@ -250,13 +250,16 @@ usage() {
     echo ""
     echo -e "${BOLD}COMMANDS:${NC}"
     echo "    list                List all configured accounts"
-    echo "    add <name>          Create a new account configuration"
+    echo "    add <name> [-m]     Create a new account configuration"
     echo "    remove <name>       Remove an account (with confirmation)"
     echo "    use <name>          Switch to an account"
     echo "    ide-setup           Configure IDE integration (VSCode)"
     echo "    shell-init          Print shell aliases (alternative to wrapper scripts)"
     echo "    version             Show version information"
     echo "    help                Show this help message"
+    echo ""
+    echo -e "${BOLD}OPTIONS:${NC}"
+    echo "    -m, --migrate       Copy settings, skills, and project history from ~/.claude"
     echo ""
     echo -e "${BOLD}QUICK START:${NC}"
     echo "    claudewho add work       # Creates 'work' account"
@@ -327,13 +330,136 @@ list_accounts() {
     echo -e "Switch with ${BOLD}claudewho use <name>${NC}"
 }
 
+# Convert a project directory name to a display-friendly path
+# e.g. "-Users-leolobato-Documents-Projetos-Cliq-Signos-foo" → "Documents/Projetos/Cliq/Signos/foo"
+project_display_path() {
+    local dirname="$1"
+    local path
+    path=$(echo "$dirname" | sed 's/^-/\//' | tr '-' '/')
+    # Strip home directory prefix
+    path="${path#"$HOME"/}"
+    echo "$path"
+}
+
+# Get the group key (first 4 path segments) for a project directory name
+project_group_key() {
+    local dirname="$1"
+    local display
+    display=$(project_display_path "$dirname")
+    echo "$display" | awk -F'/' '{
+        n = NF < 4 ? NF : 4
+        for (i = 1; i <= n; i++) {
+            if (i > 1) printf "/"
+            printf "%s", $i
+        }
+        print ""
+    }'
+}
+
+# Find the longest common directory prefix from lines on stdin
+find_common_prefix() {
+    local prefix=""
+    local first="true"
+    while IFS= read -r line; do
+        if [[ "$first" == "true" ]]; then
+            prefix="$line"
+            first="false"
+        else
+            # Narrow prefix character by character
+            local i=0
+            local len=${#prefix}
+            [[ ${#line} -lt $len ]] && len=${#line}
+            while [[ $i -lt $len ]] && [[ "${prefix:$i:1}" == "${line:$i:1}" ]]; do
+                ((i++))
+            done
+            prefix="${prefix:0:$i}"
+        fi
+    done
+    # Trim to last / boundary so we strip whole segments
+    if [[ "$prefix" == */* ]]; then
+        prefix="${prefix%/*}/"
+    else
+        prefix=""
+    fi
+    echo "$prefix"
+}
+
+# Migrate configuration from default .claude directory
+migrate_default_config() {
+    local target_dir="$1"
+    local source_dir="$HOME/.claude"
+
+    if [[ ! -d "$source_dir" ]]; then
+        echo -e "${YELLOW}Warning:${NC} Default Claude directory ($source_dir) not found. Skipping migration."
+        return 0
+    fi
+
+    echo -e "${BOLD}Migrating from${NC} $source_dir..."
+    echo ""
+
+    local migrated=0
+
+    # Configuration files
+    for file in CLAUDE.md settings.json settings.local.json; do
+        if [[ -f "$source_dir/$file" ]]; then
+            cp "$source_dir/$file" "$target_dir/$file"
+            echo -e "  ${GREEN}Copied${NC} $file"
+            ((migrated++))
+        fi
+    done
+
+    # Directories
+    for dir_name in skills plugins projects todos tasks; do
+        if [[ -d "$source_dir/$dir_name" ]]; then
+            cp -R "$source_dir/$dir_name" "$target_dir/$dir_name"
+            local count
+            count=$(find "$target_dir/$dir_name" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')
+            echo -e "  ${GREEN}Copied${NC} $dir_name/ ($count items)"
+            ((migrated++))
+        fi
+    done
+
+    echo ""
+    if [[ $migrated -gt 0 ]]; then
+        echo -e "${GREEN}Migrated $migrated items from default configuration.${NC}"
+    else
+        echo -e "${YELLOW}No configuration items found to migrate.${NC}"
+    fi
+}
+
 # Add a new account
 add_account() {
-    local name="${1:-}"
+    local name=""
+    local migrate="false"
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --migrate|-m)
+                migrate="true"
+                shift
+                ;;
+            -*)
+                echo -e "${RED}Error:${NC} Unknown option '$1'"
+                echo "Usage: claudewho add <name> [--migrate]"
+                exit 1
+                ;;
+            *)
+                if [[ -z "$name" ]]; then
+                    name="$1"
+                else
+                    echo -e "${RED}Error:${NC} Unexpected argument '$1'"
+                    echo "Usage: claudewho add <name> [--migrate]"
+                    exit 1
+                fi
+                shift
+                ;;
+        esac
+    done
 
     if [[ -z "$name" ]]; then
         echo -e "${RED}Error:${NC} Account name required"
-        echo "Usage: claudewho add <name>"
+        echo "Usage: claudewho add <name> [--migrate]"
         exit 1
     fi
 
@@ -379,6 +505,12 @@ add_account() {
 
     echo "Launch Claude with this account:"
     echo "    claudewho-${name}"
+
+    # Run migration if requested
+    if [[ "$migrate" == "true" ]]; then
+        echo ""
+        migrate_default_config "$dir"
+    fi
 }
 
 # Remove an account

--- a/bin/claudewho
+++ b/bin/claudewho
@@ -452,17 +452,15 @@ select_and_copy_projects() {
             printf "  %2d. [%s] %s (%d %s)\n" "$((i+1))" "$check" "$label" "$count" "$unit"
         done
         echo ""
-        echo -e "Toggle: ${BOLD}1-${#sorted_keys[@]}${NC}, ${BOLD}a${NC}=all, ${BOLD}n${NC}=none, ${BOLD}enter${NC}=done"
+        echo -e "Toggle: ${BOLD}1-${#sorted_keys[@]}${NC} (comma-separated), ${BOLD}a${NC}=all, ${BOLD}n${NC}=none, ${BOLD}d${NC}=done"
 
         read -rp "> " input
 
-        # Empty input = done
-        if [[ -z "$input" ]]; then
-            break
-        fi
-
         # Handle special commands
         case "$input" in
+            d|D)
+                break
+                ;;
             a|A)
                 for (( i=0; i<${#sorted_keys[@]}; i++ )); do
                     selected[$i]=1
@@ -473,6 +471,9 @@ select_and_copy_projects() {
                 for (( i=0; i<${#sorted_keys[@]}; i++ )); do
                     selected[$i]=0
                 done
+                continue
+                ;;
+            "")
                 continue
                 ;;
         esac

--- a/bin/claudewho
+++ b/bin/claudewho
@@ -251,6 +251,7 @@ usage() {
     echo -e "${BOLD}COMMANDS:${NC}"
     echo "    list                List all configured accounts"
     echo "    add <name> [-m]     Create a new account configuration"
+    echo "    migrate <name>      Migrate settings and projects from ~/.claude"
     echo "    remove <name>       Remove an account (with confirmation)"
     echo "    use <name>          Switch to an account"
     echo "    ide-setup           Configure IDE integration (VSCode)"
@@ -258,8 +259,8 @@ usage() {
     echo "    version             Show version information"
     echo "    help                Show this help message"
     echo ""
-    echo -e "${BOLD}OPTIONS:${NC}"
-    echo "    -m, --migrate       Copy settings, skills, and project history from ~/.claude"
+    echo -e "${BOLD}OPTIONS (add):${NC}"
+    echo "    -m, --migrate       Also run migration after creating the account"
     echo ""
     echo -e "${BOLD}QUICK START:${NC}"
     echo "    claudewho add work       # Creates 'work' account"
@@ -879,6 +880,32 @@ shell_init() {
     done <<< "$accounts"
 }
 
+# Migrate configuration to an existing account
+migrate_account() {
+    local name="${1:-}"
+
+    if [[ -z "$name" ]]; then
+        echo -e "${RED}Error:${NC} Account name required"
+        echo "Usage: claudewho migrate <name>"
+        exit 1
+    fi
+
+    if ! account_exists "$name"; then
+        echo -e "${RED}Error:${NC} Account '$name' not found"
+        echo "Run 'claudewho list' to see available accounts."
+        exit 1
+    fi
+
+    local dir="${CONFIG_DIR_PREFIX}${name}"
+
+    if [[ ! -d "$dir" ]]; then
+        echo -e "${RED}Error:${NC} Account directory $dir is missing"
+        exit 1
+    fi
+
+    migrate_default_config "$dir"
+}
+
 # Main command router
 main() {
     local cmd="${1:-help}"
@@ -890,6 +917,9 @@ main() {
             ;;
         add|create|new)
             add_account "$@"
+            ;;
+        migrate)
+            migrate_account "$@"
             ;;
         remove|delete|rm)
             remove_account "$@"

--- a/bin/claudewho
+++ b/bin/claudewho
@@ -551,34 +551,45 @@ migrate_default_config() {
     echo -e "${BOLD}Migrating from${NC} $source_dir..."
     echo ""
 
-    local migrated=0
-
-    # Configuration files
+    # Configuration files (skip existing)
     for file in CLAUDE.md settings.json settings.local.json; do
         if [[ -f "$source_dir/$file" ]]; then
-            cp "$source_dir/$file" "$target_dir/$file"
-            echo -e "  ${GREEN}Copied${NC} $file"
-            ((migrated++))
+            if [[ -f "$target_dir/$file" ]]; then
+                echo -e "  ${YELLOW}Skipped${NC} $file (already exists)"
+            else
+                cp "$source_dir/$file" "$target_dir/$file"
+                echo -e "  ${GREEN}Copied${NC} $file"
+            fi
         fi
     done
 
-    # Directories
-    for dir_name in skills plugins projects todos tasks; do
+    # Directories (copy contents, skip existing entries)
+    for dir_name in skills plugins todos tasks; do
         if [[ -d "$source_dir/$dir_name" ]]; then
-            cp -R "$source_dir/$dir_name" "$target_dir/$dir_name"
-            local count
-            count=$(find "$target_dir/$dir_name" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')
-            echo -e "  ${GREEN}Copied${NC} $dir_name/ ($count items)"
-            ((migrated++))
+            mkdir -p "$target_dir/$dir_name"
+            local copied=0
+            local skipped=0
+            for entry in "$source_dir/$dir_name"/*; do
+                [[ -e "$entry" ]] || continue
+                local entry_name
+                entry_name=$(basename "$entry")
+                if [[ -e "$target_dir/$dir_name/$entry_name" ]]; then
+                    ((skipped++))
+                else
+                    cp -R "$entry" "$target_dir/$dir_name/$entry_name"
+                    ((copied++))
+                fi
+            done
+            if [[ $copied -gt 0 ]]; then
+                echo -e "  ${GREEN}Copied${NC} $dir_name/ ($copied copied"$([[ $skipped -gt 0 ]] && echo ", $skipped skipped")")"
+            elif [[ $skipped -gt 0 ]]; then
+                echo -e "  ${YELLOW}Skipped${NC} $dir_name/ ($skipped already exist)"
+            fi
         fi
     done
 
-    echo ""
-    if [[ $migrated -gt 0 ]]; then
-        echo -e "${GREEN}Migrated $migrated items from default configuration.${NC}"
-    else
-        echo -e "${YELLOW}No configuration items found to migrate.${NC}"
-    fi
+    # Projects (interactive selection)
+    select_and_copy_projects "$source_dir" "$target_dir"
 }
 
 # Add a new account


### PR DESCRIPTION
Adds the ability to migrate configurations, skills, and project history from the default `~/.claude` directory to a claudewho account.

### New: `claudewho migrate <name>`

Standalone command that copies settings, skills, plugins, todos, tasks, and projects to an existing account. Also available as `claudewho add <name> --migrate` during account creation.

**Interactive project selector** - projects are grouped by path prefix and presented as a numbered multi-select, so you can pick which project groups to bring over:

```
Select project groups to migrate (89 projects):

   1. [ ] personal/project (1 project)
   2. [ ] clients/client1 (18 projects)
   3. [x] clients/client2 (30 projects)

Toggle: 1-3 (comma-separated), a=all, n=none, d=done
```

**Safe to re-run** - existing items are skipped, so you can migrate new projects later without overwriting anything.

### Other changes

- Shows a migration tip when creating an account without `--migrate`
- Updated help text and README
